### PR TITLE
Fix tests for MSVC

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -17,6 +17,7 @@ project
         <toolset>pathscale:<cxxflags>-Wno-long-long
         <toolset>gcc:<cxxflags>-Wcast-align
         <toolset>msvc:<warnings-as-errors>on
+        <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     ;
 
 import testing ;


### PR DESCRIPTION
warnings-as-errors caused the simple_seg_storage and threading tests to fail on all Visual C++ compilers. This define suppresses the warnings about unchecked iterators, which I don't think are solvable in a portable way.
