### PR TITLE
Update test_poisoned_macros.cpp

### DIFF
--- a/test/test_poisoned_macros.cpp
+++ b/test/test_poisoned_macros.cpp
@@ -19,8 +19,15 @@
 #include <iostream>
 #include <locale>
 
-#define malloc(x) undefined_poisoned_symbol
-#define free(x) undefined_poisoned_symbol
+namespace std{
+
+   void* undefined_poisoned_symbol1(unsigned x);
+   void undefined_poisoned_symbol2(void* x);
+
+}
+
+#define malloc(x) undefined_poisoned_symbol1(x)
+#define free(x) undefined_poisoned_symbol2(x)
 
 #include <boost/pool/pool.hpp>
 #include <boost/pool/object_pool.hpp>


### PR DESCRIPTION
Current test fails inside /boost/core/demangle.hpp: not sure why that header is even included, but anyway this fix solves the issue while preserving the intent of the test.
