### PR TITLE
Cxx11 allocator compliance

### DIFF
--- a/include/boost/pool/pool_alloc.hpp
+++ b/include/boost/pool/pool_alloc.hpp
@@ -411,8 +411,16 @@ class fast_pool_allocator
     { return &s; }
     static size_type max_size()
     { return (std::numeric_limits<size_type>::max)(); }
+
+#ifdef BOOST_HAS_VARIADIC_TMPL
+    template <typename U, typename... Args>
+    void construct(U* ptr, Args&&... args)
+    { new (ptr) U(std::forward<Args>(args)...); }
+#else
     void construct(const pointer ptr, const value_type & t)
     { new (ptr) T(t); }
+#endif
+
     void destroy(const pointer ptr)
     { //! Destroy ptr using destructor.
       ptr->~T();

--- a/include/boost/pool/pool_alloc.hpp
+++ b/include/boost/pool/pool_alloc.hpp
@@ -79,6 +79,14 @@ STLport (with any compiler), ver. 4.0 and earlier.
 
 #include <boost/detail/workaround.hpp>
 
+// C++11 features detection
+#include <boost/config.hpp>
+
+// std::forward
+#ifdef BOOST_HAS_VARIADIC_TMPL
+#include <utility>
+#endif
+
 #ifdef BOOST_POOL_INSTRUMENT
 #include <iostream>
 #include <iomanip>
@@ -206,8 +214,16 @@ class pool_allocator
     { return &s; }
     static size_type max_size()
     { return (std::numeric_limits<size_type>::max)(); }
+
+#ifdef BOOST_HAS_VARIADIC_TMPL
+    template <typename U, typename... Args>
+    static void construct(U* ptr, Args&&... args)
+    { new (ptr) U(std::forward<Args>(args)...); }
+#else
     static void construct(const pointer ptr, const value_type & t)
     { new (ptr) T(t); }
+#endif
+
     static void destroy(const pointer ptr)
     {
       ptr->~T();

--- a/include/boost/pool/pool_alloc.hpp
+++ b/include/boost/pool/pool_alloc.hpp
@@ -215,7 +215,7 @@ class pool_allocator
     static size_type max_size()
     { return (std::numeric_limits<size_type>::max)(); }
 
-#ifdef BOOST_HAS_VARIADIC_TMPL
+#if defined(BOOST_HAS_VARIADIC_TMPL) && defined(BOOST_HAS_RVALUE_REFS)
     template <typename U, typename... Args>
     static void construct(U* ptr, Args&&... args)
     { new (ptr) U(std::forward<Args>(args)...); }
@@ -412,7 +412,7 @@ class fast_pool_allocator
     static size_type max_size()
     { return (std::numeric_limits<size_type>::max)(); }
 
-#ifdef BOOST_HAS_VARIADIC_TMPL
+#if defined(BOOST_HAS_VARIADIC_TMPL) && defined(BOOST_HAS_RVALUE_REFS)
     template <typename U, typename... Args>
     void construct(U* ptr, Args&&... args)
     { new (ptr) U(std::forward<Args>(args)...); }


### PR DESCRIPTION
`pool_allocator` and `fast_pool_allocator` are not compliant to the C++11 allocator interface. Besides some methods being `static` when they should be instance methods and `const` qualified (also `noexcept` qualified on C++11), `(fast_)pool_allocator::construct` should take a variadic template parameter pack rather than just a `const value_type&`, which makes it fail to compile when using it with containers such as libstdc++'s `unordered_map`. 

This patch detects whether variadic templates are supported and defines the `construct` method using the appropriate signature. This should be backwards compatible.

I also wanted to change the signature of the currently static methods methods, but I guess that might break some code that's relying on them being static.

This is a sample code that wouldn't compile without this patch:

``` c++
#include <boost/pool/pool_alloc.hpp>
#include <unordered_map>

using map_type = std::unordered_map<
    int,
    int,
    std::hash<int>,
    std::equal_to<int>,
    boost::fast_pool_allocator<std::pair<int, int>>
>;

int main() {
    map_type mt;
    mt[42] = 42;
}
```
