### PR TITLE
use std::mutex if available

### DIFF
--- a/include/boost/pool/detail/mutex.hpp
+++ b/include/boost/pool/detail/mutex.hpp
@@ -9,9 +9,13 @@
 #ifndef BOOST_POOL_MUTEX_HPP
 #define BOOST_POOL_MUTEX_HPP
 
-#include <boost/config.hpp>  // for workarounds
-#if defined (BOOST_HAS_THREADS) && !defined(BOOST_POOL_NO_MT)
-#include <boost/thread/mutex.hpp>
+#include <boost/config.hpp>  // for workarounds                                                                        
+#if defined (BOOST_HAS_THREADS) && !defined(BOOST_POOL_NO_MT)                                                          
+#if defined (BOOST_NO_CXX11_HDR_MUTEX)                                                                                 
+#include <boost/thread/mutex.hpp>                                                                                      
+#else                                                                                                                  
+#include <mutex>                                                                                                       
+#endif                                                                                                                 
 #endif
 
 namespace boost{ namespace details{ namespace pool{
@@ -29,10 +33,14 @@ class null_mutex
     static void unlock() { }
 };
 
-#if !defined(BOOST_HAS_THREADS) || defined(BOOST_NO_MT) || defined(BOOST_POOL_NO_MT)
-  typedef null_mutex default_mutex;
-#else
-  typedef boost::mutex default_mutex;
+#if !defined(BOOST_HAS_THREADS) || defined(BOOST_NO_MT) || defined(BOOST_POOL_NO_MT)                                   
+  typedef null_mutex default_mutex;                                                                                    
+#else                                                                                                                  
+#if defined (BOOST_NO_CXX11_HDR_MUTEX)                                                                                 
+  typedef boost::mutex default_mutex;                                                                                  
+#else                                                                                                                  
+  typedef std::mutex default_mutex;                                                                                    
+#endif                                                                                                                 
 #endif
 
 } // namespace pool


### PR DESCRIPTION
if compiled for C++11 etc. use std::mutex. drawback of boost::mutex is that boost.thread depends on boost.system (requires linking against boost.system). boost.system is already part of C++11.
Additionally boost::mutex is much more slower than std::mutex!