### PR TITLE
Do not use std::auto_ptr.

### DIFF
--- a/test/test_bug_5526.cpp
+++ b/test/test_bug_5526.cpp
@@ -7,7 +7,7 @@
 
 // Test of bug #2656 (https://svn.boost.org/trac/boost/ticket/2526)
 
-#include <memory> 
+#include <boost/smart_ptr/scoped_ptr.hpp>
 #include <boost/pool/pool.hpp>
 #include <boost/pool/singleton_pool.hpp>
 #include <boost/assert.hpp>
@@ -27,7 +27,7 @@ struct bad
    int* buf;
 };
 
-std::auto_ptr<bad> aptr;
+boost::scoped_ptr<bad> aptr;
 
 int main() 
 {


### PR DESCRIPTION
Use boost::scoped_ptr instead in this use case.

see [Flast-FreeBSD10-gcc-5.3.0~gnu++11 - pool - test_bug_5526 / gcc-5.3.0](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD10-gcc-5-3-0~gnu++11-boost-bin-v2-libs-pool-test-test_bug_5526-test-gcc-5-3-0-debug.html)