### PR TITLE
Fix double delete in new_delete_allocator

### DIFF
--- a/example/sys_allocator.hpp
+++ b/example/sys_allocator.hpp
@@ -86,7 +86,7 @@ struct new_delete_allocator
   static pointer allocate(const size_type n, const void* = 0)
   { return (pointer) new char[n * sizeof(T)]; }
   static void deallocate(const pointer p, const size_type)
-  { delete [] p; }
+  { delete [] (char*)p; }
   static size_type max_size() { return (std::numeric_limits<size_type>::max)(); }
 
   bool operator==(const new_delete_allocator &) const { return true; }


### PR DESCRIPTION
The `deallocate` method of `new_delete_allocator` currently invokes the destructor on the supplied pointer. To prevent this it needs to be cast back to a `char*` first.