### PR TITLE
Do not use test rules to check for valgrind

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,12 +18,21 @@ project
         <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     ;
 
+import common ;
 import testing ;
 
-run valgrind_config_check.cpp : : : <testing.launcher>"valgrind --error-exitcode=1" ;
+obj valgrind_config_check : valgrind_config_check.cpp ;
 explicit valgrind_config_check ;
 
-local use-valgrind = [ check-target-builds valgrind_config_check "valgrind" : <testing.launcher>"valgrind --error-exitcode=1" : <build>no ] ;
+local VALGRIND = [ common.find-tool valgrind ] ;
+
+local use-valgrind = <build>no ;
+if $(VALGRIND)
+{
+    use-valgrind = [ check-target-builds valgrind_config_check "valgrind"
+                   : <testing.launcher>"$(VALGRIND) --error-exitcode=1"
+                   : <build>no ] ;
+}
 
 local Werr = <toolset>gcc:<warnings-as-errors>on <toolset>msvc:<warnings-as-errors>on ;
 


### PR DESCRIPTION
Passing a test rule to `check-target-builds` affects `--dump-tests` output,
some tests disappears what causes the missing tests in regression matrix.

This was discovered at modularizing Spirit tests (tests under `build-project`
dirs runs, but do not appear in `--dump-tests` output)