### PR TITLE
[CMake] Add test for cmake file

### DIFF
--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: This does NOT run the unit tests for Boost.Pool.
+#       It only tests, if the CMakeLists.txt file in it's root works as expected
+
+cmake_minimum_required( VERSION 3.5 )
+
+project( BoostPool_TestCMake LANGUAGES CXX )
+
+set( dependencies
+        assert;
+        config;
+        core;
+        integer;
+        throw_exception;
+        type_traits;
+        static_assert;
+        predef;
+        winapi
+)
+
+foreach( lib IN LISTS dependencies )
+    add_subdirectory( ../../../${lib} ${CMAKE_CURRENT_BINARY_DIR}/libs/${lib} )
+endforeach()
+
+add_subdirectory( ../.. ${CMAKE_CURRENT_BINARY_DIR}/libs/boost_pool )
+
+add_executable( boost_pool_test_cmake main.cpp )
+target_link_libraries( boost_pool_test_cmake Boost::pool )
+

--- a/test/test_cmake/main.cpp
+++ b/test/test_cmake/main.cpp
@@ -1,0 +1,19 @@
+/* Copyright 2018 Mike Dev
+ * Distributed under the Boost Software License, Version 1.0.
+ * See accompanying file LICENSE_1_0.txt or copy at https ://www.boost.org/LICENSE_1_0.txt
+ */
+
+/* Verfiy that we can find all hederfiles
+ * from this library as well as the
+ * transitively included ones
+ */
+#include <boost/pool/poolfwd.hpp>
+#include <boost/pool/object_pool.hpp>
+#include <boost/pool/pool.hpp>
+#include <boost/pool/pool_alloc.hpp>
+#include <boost/pool/simple_segregated_storage.hpp>
+#include <boost/pool/singleton_pool.hpp>
+
+int main() {
+
+}


### PR DESCRIPTION
Use: 
- create and cd into a build directory (preferably out of tree)
- `cmake <path-to-boost-pool>/test/test_cmake`
- `cmake --build . (same as make on linux systems)`

This requires that all dependencies are placed in sibling directories to boost pool (as is e.g. the case when cloning the boost super project)

Unfortunately, I don't know how to integrate it into your travis script.