### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/pool/object_pool.hpp
+++ b/include/boost/pool/object_pool.hpp
@@ -26,7 +26,7 @@ It also provides automatic destruction of non-deallocated objects.
 #endif
 
 // The following code might be put into some Boost.Config header in a later revision
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 # pragma option push -w-inl
 #endif
 
@@ -280,7 +280,7 @@ object_pool<T, UserAllocator>::~object_pool()
 } // namespace boost
 
 // The following code might be put into some Boost.Config header in a later revision
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 # pragma option pop
 #endif
 

--- a/include/boost/pool/pool_alloc.hpp
+++ b/include/boost/pool/pool_alloc.hpp
@@ -94,7 +94,7 @@ STLport (with any compiler), ver. 4.0 and earlier.
 
 // The following code will be put into Boost.Config in a later revision
 #if defined(_RWSTD_VER) || defined(__SGI_STL_PORT) || \
-    BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+    BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
  #define BOOST_NO_PROPER_STL_DEALLOCATE
 #endif
 


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.