### PR TITLE
Docs: fix formatting of two examples, improve grammar

### DIFF
--- a/doc/pool.qbk
+++ b/doc/pool.qbk
@@ -192,13 +192,13 @@ Pool interfaces will always prefer to `return 0` instead of throwing an exceptio
 
 [h5 Ordered versus unordered]
 
-An ordered pool maintains it's free list in order of the address of each free block - 
+An ordered pool maintains its free list in order of the address of each free block - 
 this is the most efficient way if you're likely to allocate arrays of objects.
 However, freeing an object can be O(N) in the number of currently free blocks which 
 can be prohibitively expensive in some situations.
 
-An unordered pool does not maintain it's free list in any particular order, as a result
-allocation and freeing single objects is very fast, but allocating arrays may be slow 
+An unordered pool does not maintain its free list in any particular order, as a result
+allocating and freeing single objects is very fast, but allocating arrays may be slow 
 (and in particular the pool may not be aware that it contains enough free memory for the
 allocation request, and unnecessarily allocate more memory).
 
@@ -351,6 +351,7 @@ Defines the method that the underlying Pool will use to allocate memory from the
 Default is default_user_allocator_new_delete.  See ____UserAllocator for details.
 
 [*Example:]
+
   struct X { ... }; // has destructor with side-effects.
 
   void func()
@@ -437,6 +438,7 @@ Must be greater than 0.
 Defines the method that the underlying pool will use to allocate memory from the system. See User Allocators for details.
 
 [*Example:]
+
   struct MyPoolTag { };
 
   typedef boost::singleton_pool<MyPoolTag, sizeof(int)> my_pool;


### PR DESCRIPTION
I really tried to generate the html files, but after figuring out that I need quickbook and figuring out how to install it, I'm getting the following error:
```
/home/eli/pool/doc/jamfile.v2:118: Unescaped special character in argument <format>pdf:<xsl:param>boost.url.prefix=I:/boost-sandbox/guild/pool/libs/pool/doc/html
/home/eli/pool/doc/jamfile.v2:46: in modules.load
*** argument error
* rule doxygen ( target : sources + : requirements * : default-build * : usage-requirements * )
* called with: ( autodoc :  : <doxygen:param>WARNINGS=YES <doxygen:param>WARN_LOGFILE=AutoDoxywarnings.log <doxygen:param>RECURSIVE=NO <doxygen:param>EXTRACT_ALL=NO <doxygen:param>HIDE_UNDOC_MEMBERS=YES <doxygen:param>EXTRACT_PRIVATE=NO <doxygen:param>MACRO_EXPANSION=YES <doxygen:param>EXPAND_ONLY_PREDEF=YES <doxygen:param>PREDEFINED="BOOST_PREVENT_MACRO_SUBSTITUTION=" "BOOST_STATIC_CONSTANT(t,v)=static const t v" "BOOST_DOXYGEN=1" <xsl:param>boost.doxygen.reftitle=Boost.Pool C++ Reference )
* missing argument sources
/home/eli/Downloads/boost_1_74_0/tools/build/src/tools/doxygen.jam:627:see definition of rule 'doxygen' being called
/home/eli/Downloads/boost_1_74_0/tools/build/src/build/project.jam:372: in load-jamfile
/home/eli/Downloads/boost_1_74_0/tools/build/src/build/project.jam:64: in load
/home/eli/Downloads/boost_1_74_0/tools/build/src/build/project.jam:142: in project.find
/home/eli/Downloads/boost_1_74_0/tools/build/src/build/targets.jam:453: in find-really
/home/eli/Downloads/boost_1_74_0/tools/build/src/build/targets.jam:475: in class@project-target.find
/home/eli/Downloads/boost_1_74_0/tools/build/src/build-system.jam:724: in load
/home/eli/Downloads/boost_1_74_0/tools/build/src/kernel/modules.jam:295: in import
/home/eli/Downloads/boost_1_74_0/tools/build/src/kernel/bootstrap.jam:139: in boost-build
/home/eli/Downloads/boost_1_74_0/boost-build.jam:17: in module scope
```

I'd humbly suggest making it easier to contribute documentation fixes.