### PR TITLE
fix integer overflows in pool::ordered_malloc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
             b2_defines: "define=BOOST_NO_STRESS_TEST=1"
             b2_variant: "variant=debug"
             b2_testflags: "testing.launcher=valgrind"
-            valgrind_opts: "--error-exitcode=1"
+            valgrind_opts: "--error-exitcode=1 --suppressions=libs/pool/test/suppressions.txt"
           - name: "COMMENT=Coverity Scan B2_TOOLSET=clang Job 17"
             buildtype: "b5847f804b-cce9827eb5"
             packages: "binutils-gold gdb libc6-dbg"

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -34,6 +34,7 @@ test-suite pool :
         <toolset>pathscale:<cxxflags>-Wno-long-long ]
     [ run test_bug_2696.cpp ]
     [ run test_bug_5526.cpp ]
+    [ run test_bug_6701.cpp ]
     [ run test_threading.cpp : : : <threading>multi <library>/boost/thread//boost_thread ]
     [ compile test_poisoned_macros.cpp ]
     ;

--- a/test/suppressions.txt
+++ b/test/suppressions.txt
@@ -1,0 +1,7 @@
+{
+   no_fishy_value
+   Memcheck:FishyValue
+   __builtin_vec_new(size)
+   fun:_ZnamRKSt9nothrow_t
+   ...
+}

--- a/test/test_bug_6701.cpp
+++ b/test/test_bug_6701.cpp
@@ -1,0 +1,27 @@
+/* Copyright (C) 2012 Étienne Dupuis
+*
+* Use, modification and distribution is subject to the
+* Boost Software License, Version 1.0. (See accompanying
+* file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+// Test of bug #6701 (https://svn.boost.org/trac/boost/ticket/6701)
+
+#include <boost/pool/object_pool.hpp>
+#include <boost/limits.hpp>
+
+int main()
+{
+  boost::pool<> p(1024, std::numeric_limits<size_t>::max() / 768);
+
+  void *x = p.malloc();
+  BOOST_ASSERT(!x);
+
+  BOOST_ASSERT(std::numeric_limits<size_t>::max() / 1024 >= p.get_next_size());
+  BOOST_ASSERT(std::numeric_limits<size_t>::max() / 1024 >= p.get_max_size());
+
+  void *y = p.ordered_malloc(std::numeric_limits<size_t>::max() / 768);
+  BOOST_ASSERT(!y);
+
+  return 0;
+}


### PR DESCRIPTION
Fixes trac #6701 (https://svn.boost.org/trac10/ticket/6701).

Originally-by: @jwakely