### PR TITLE
Allow object_pool::construct() to use variadic template, if available.

### DIFF
--- a/include/boost/pool/object_pool.hpp
+++ b/include/boost/pool/object_pool.hpp
@@ -175,6 +175,18 @@ class object_pool: protected pool<UserAllocator>
        //! detail/pool_construct.bat and detail/pool_construct.sh are also provided to call m4, defining NumberOfArguments 
        //! to be their command-line parameter. See these files for more details.
     }
+#elif defined(BOOST_HAS_VARIADIC_TMPL) && defined(BOOST_HAS_RVALUE_REFS)
+    // When available, use variadic templates to avoid the older '.ipp'/'.m4' implementation
+    template <typename... Args>
+    element_type * construct(Args&&... args)
+    {
+        element_type* const ret = (malloc)();
+        if (ret == 0)
+            return ret;
+        try { new (ret) element_type(std::forward<Args>(args)...); }
+        catch (...) { (free)(ret); throw; }
+        return ret;
+    }
 #else
 // Include automatically-generated file for family of template construct() functions.
 // Copy .inc renamed .ipp to conform to Doxygen include filename expectations, PAB 12 Jan 11.

--- a/include/boost/pool/pool.hpp
+++ b/include/boost/pool/pool.hpp
@@ -969,6 +969,8 @@ public:
      if(free_list.empty())
      {
         ret = (user_allocator::malloc)(chunk_size);
+        if ( ret == 0 )
+           return ret;
         VALGRIND_MAKE_MEM_UNDEFINED(ret, chunk_size);
      }
      else


### PR DESCRIPTION
As @jbherdman suggested I'm opening a new pull request with all of their changes in one commit. Hopefully, we get an accurate Code Coverage Report that way. 

This PR doesn't contain any new code that wasn't already included in PR 31.

Fixes issue https://github.com/boostorg/pool/issues/22, with a fallback to the existing code for compilers that don't support variadic-templates.