### PR TITLE
Allow compile with MSVC and Windows headers (#49)

### DIFF
--- a/include/boost/pool/pool.hpp
+++ b/include/boost/pool/pool.hpp
@@ -360,7 +360,7 @@ class pool: protected simple_segregated_storage < typename UserAllocator::size_t
     size_type max_chunks() const
     { //! Calculated maximum number of memory chunks that can be allocated in a single call by this Pool.
       size_type POD_size = integer::static_lcm<sizeof(size_type), sizeof(void *)>::value + sizeof(size_type);
-      return (std::numeric_limits<size_type>::max() - POD_size) / alloc_size();
+      return ((std::numeric_limits<size_type>::max)() - POD_size) / alloc_size();
     }
 
     static void * & nextof(void * const ptr)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -38,6 +38,7 @@ test-suite pool :
     [ run test_bug_6701.cpp ]
     [ run test_threading.cpp : : : <threading>multi <library>/boost/thread//boost_thread ]
     [ compile test_poisoned_macros.cpp ]
+    [ compile test_issue_49.cpp ]
     ;
 
 if [ os.environ VALGRIND_OPTS ]

--- a/test/test_issue_49.cpp
+++ b/test/test_issue_49.cpp
@@ -1,0 +1,19 @@
+/* Copyright (C) 2022 Joel Pelaez Jorge
+*
+* Use, modification and distribution is subject to the
+* Boost Software License, Version 1.0. (See accompanying
+* file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+// Test of issue #49 (https://github.com/boostorg/pool/issues/49)
+
+#if defined (_WIN32)
+# include <Windows.h>
+#endif
+#include <boost/pool/pool.hpp>
+
+int main()
+{
+  boost::pool<> p(1024);
+  return 0;
+}


### PR DESCRIPTION
When the boost::pool is instantiated and the code is compiled with
MSVC compiler, it can fail if Windows specific headers are included,
adding the max and min macros.

Because some part of the header file already has preprocessor guards,
this change add same solution to call to std::numeric_limits<>::max()
to avoid any issues.

On MSVC using C++20 standard mode, the header file also fires the same
issue, only with include it on code file, without require object
instantiation.