### PR TITLE
Do not extend the pool on each allocation

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -37,6 +37,7 @@ test-suite pool :
     [ run test_bug_2696.cpp ]
     [ run test_bug_5526.cpp : : : <library>/boost/smart_ptr//boost_smart_ptr [ requires cxx11_noexcept ] ]
     [ run test_bug_6701.cpp ]
+    [ run test_bug_54.cpp ]
     [ run test_threading.cpp : : : <threading>multi <library>/boost/thread//boost_thread <library>/boost/random//boost_random ]
     [ compile test_poisoned_macros.cpp ]
     ;

--- a/test/test_bug_54.cpp
+++ b/test/test_bug_54.cpp
@@ -1,0 +1,26 @@
+/* Copyright (C) 2023 Orgad Shaneh
+*
+* Use, modification and distribution is subject to the
+* Boost Software License, Version 1.0. (See accompanying
+* file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+// Test of bug #54 (https://github.com/boostorg/pool/issues/54)
+
+#include <boost/pool/pool.hpp>
+#include <boost/limits.hpp>
+
+int main()
+{
+  boost::pool<> pool(8, 32, 64);
+  // On 32 next_size reaches max_size.
+  // One more round to asserts that it remains 64 (max_size)
+  for (int i = 0; i <= 33; ++i) {
+	size_t expected = (i == 0) ? 32 : 64;
+	BOOST_ASSERT(pool.get_next_size() == expected);
+	void *ptr = pool.malloc();
+	BOOST_ASSERT(ptr);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Reported in Boost mailing list: https://lists.boost.org/Archives/boost/2023/06/254750.php

Commit 951ca57 changed malloc_need_resize() to use set_next_size(), which sets start_size in addition to setting next_size. this causes repeated use of purge_memory() to allocate 2x size after every use.

Fixes #54