### PR TITLE
Revert PR #53

### DIFF
--- a/include/boost/pool/simple_segregated_storage.hpp
+++ b/include/boost/pool/simple_segregated_storage.hpp
@@ -328,19 +328,6 @@ void * simple_segregated_storage<SizeType>::try_malloc_n(
     void * & start, size_type n, const size_type partition_size)
 {
   void * iter = nextof(start);
-  if (n == 1)
-  {
-    void * next = nextof(iter);
-    if (next != static_cast<char *>(iter) + partition_size)
-    {
-      start = iter;
-      return 0;
-    }
-    else
-    {
-      return iter;
-    }
-  }
   while (--n != 0)
   {
     void * next = nextof(iter);

--- a/test/test_simple_seg_storage.cpp
+++ b/test/test_simple_seg_storage.cpp
@@ -316,44 +316,6 @@ int main()
         }
 
         {
-            char* const pc = track_allocator::malloc(4 * partition_sz);
-            test_simp_seg_store tstore;
-            tstore.add_ordered_block(pc, 4 * partition_sz, partition_sz);
-
-            void* pvret = tstore.malloc_n(1, 2 * partition_sz);
-            BOOST_TEST(pvret == 0);
-
-            // There should still be two contiguous
-            //  and one non-contiguous chunk left
-            std::size_t nchunks = 0;
-            while(!tstore.empty())
-            {
-                tstore.malloc();
-                ++nchunks;
-            }
-            BOOST_TEST(nchunks == 4);
-        }
-
-        {
-            char* const pc = track_allocator::malloc(4 * partition_sz);
-            test_simp_seg_store tstore;
-            tstore.add_ordered_block(pc, 4 * partition_sz, partition_sz);
-
-            void* pvret = tstore.malloc_n(2, 2 * partition_sz);
-            BOOST_TEST(pvret == 0);
-
-            // There should still be two contiguous
-            //  and one non-contiguous chunk left
-            std::size_t nchunks = 0;
-            while(!tstore.empty())
-            {
-                tstore.malloc();
-                ++nchunks;
-            }
-            BOOST_TEST(nchunks == 4);
-        }
-
-        {
             char* const pc = track_allocator::malloc(12 * partition_sz);
             test_simp_seg_store tstore;
             tstore.add_ordered_block(pc, 2 * partition_sz, partition_sz);


### PR DESCRIPTION
It looks like [PR #53](https://github.com/boostorg/pool/pull/53) has introduced a regression into `boost pool`. The present PR essentially reverts PR #53, leaving some of the changes. It also contains new unit tests demonstrating the regression.

**TL;DR**: `simple_segregated_storage` in its present form is fundamentally uncapable of handling mixed partition sizes, and cannot be "fixed" to allow that handling without a major change of the implementation. The linked-to [Example 4.1](https://theboostcpplibraries.com/boost.pool#ex.pool_01), which was a starting point for the "fix", looks simply wrong and so does the fix itself.

**The rationale for #53 being a regression is as follows.**

PR #53 purports to fix the issue of `simple_segregated_storage` not being able to correctly handle varying values of `partition_sz`. However, upon inspecting the code of `simple_segregated_storage`, it looks like the latter is not designed to simultaneously handle different values of `partition_sz` at all. Rather one and the same value is supposed to be stored externally and consistently supplied to the calls into one and the same `simple_segregated_storage` instance.

Let's go into detail of why the latter is the case. A `simple_segregated_storage` keeps an ordered list of free partitions of size `partition_sz` each, where the value of `partition_sz` is the one originally supplied to the `segregate` call. Respectively, the condition `if (next != static_cast<char *>(iter) + partition_size)` inside the `try_malloc_n()` method is checking whether the next free partition immediately follows the current free partition or not. This condition only works correctly if `partition_size` has exactly the same value as the `partition_sz` supplied earlier to `segregate`, otherwise `static_cast<char *>(iter) + partition_size` doesn't produce the end boundary of the current partition. Thus, with any other value of `partition_size` the outcome of the condition is pretty much random.

Thus, prior to #53, the `while (--n != 0)` loop in `try_malloc_n` was simply looking for additional free partitions immediately following the current free partition, all partitions adding up to a contiguous chunk of `n` partitions in total. With the added in #53 `if (n == 1)` condition, the function now fails for single-partition blocks whenever it's considering a single-partition-sized free hole, even for a correct value of `partition_size`. With other values of `partition_size` the outcomes are more random (e.g. the function might inadvertently incorporate an already allocated partition into the found "free" chunk).

Besides the above, the condition `if (n == 1)` also looks highly suspicious per se, as it's not clear why chunks of size 1 need any extra handling compared to chunks of larger sizes.


**The present PR consists (at the time of the opening) of 3 commits:**

2822004a This commit adds two unit tests to `test_pool_alloc.cpp` demonstrating the regression caused by `simple_segregated_storage` as broken functionality in `boost::pool`. Similar tests could have been implemented for `simple_segregated_storage` instead, but it was decided to do those in `test_pool_alloc.cpp`, as the latter tests the public API of the library, while `simple_segregated_storage` is more of an internal detail class. Both tests sequentially allocate 3 chunks of sizes equal to 1 partition each, expecting the chunks to be allocated immediately following each other in memory.

In the first test the pool block has the size of exactly 3 partitions, respectively the 3rd chunk, due to the regression from #53 is no longer allocated within the first pool block and gets allocated in an additionally allocated pool block, leading to the 3rd chunk being further away from the 2nd one than expected (so the test in line 310 fails). Upon freeing and reallocating the 2nd chunk the reallocated chunk may randomly appear in a different position than originally, the respective test condition `ptr_1a == ptr_1` in line 317 randomly failing or not failing. The randomness is due to undefined memory positions of the two pool blocks relative to each other. If the second pool block gets allocated at a smaller address than the first one, the reallocated 2nd chunk will be picked up from the 2nd pool block, thus appearing at a different address than before (where it was picked up from the 1st pool block), so the test in line 317 fails. If the 2nd pool block gets allocated at a larger address than the 1st one, then the partition originally occupied by the 2nd chunk is the first partition in the list of free partitions and thus will be reallocated (since the 3rd partition in the block is still free due to the bug we're discussing, the same bug doesn't kick in during reallocation of the 2nd chunk), respectively the test in line 317 does not fail. This can be confirming by adding a debug print statement into the test code, printing the addresses of the 3 chunks.

In the second test the pool block has the size of 4 partitions, thus the bug introduced by #53 doesn't kick in during the initial 3 allocations of the chunks. However, as the 3rd chunk is now at the expected position (immediately following the 2nd chunk), the bug does kick in during the reallocation of the 2nd chunk, leading to failing test in line 342.

492f9a89 This commit reverts the `if (n == 1)` condition introduced by #53 and causing the regression. This causes some of the unit tests introduced by #53 (those which test against the varying `partition_sz` value) to fail.

86b79870 This commit removes the two failing tests (of the 4 tests introduced into `test_simple_seg_storage.cpp` by #53). These tests explicitly test against the case of the varying `partition_sz` value, which is explicitly unsupported per the above discussion. Thus they are not supposed to succeed at all.

**Further remarks**

The [Example 4.1](https://theboostcpplibraries.com/boost.pool#ex.pool_01) linked from the [Issue #52](https://github.com/boostorg/pool/issues/52), looks completely wrong, as it is supplying an inconsistent value of partition size. This example only works by random chance, due to the fact that only a single partition (of a wrong size, but size doesn't matter in this case) is requested. This example was apparently the reason for the confusion in [Issue #52](https://github.com/boostorg/pool/issues/52), which [PR #53](https://github.com/boostorg/pool/pull/53) tried to fix. But by the previous argument, it cannot be fixed, the `simple_segregated_storage` cannot handle partitions of mixed sizes.