### PR TITLE
reset next_size/start_size when calling purge_memory

### DIFF
--- a/include/boost/pool/pool.hpp
+++ b/include/boost/pool/pool.hpp
@@ -310,6 +310,7 @@ class pool: protected simple_segregated_storage < typename UserAllocator::size_t
     const size_type requested_size;
     size_type next_size;
     size_type start_size;
+    size_type init_next_size;
     size_type max_size;
 
     //! finds which POD in the list 'chunk' was allocated from.
@@ -375,7 +376,7 @@ class pool: protected simple_segregated_storage < typename UserAllocator::size_t
         const size_type nnext_size = 32,
         const size_type nmax_size = 0)
     :
-        list(0, 0), requested_size(nrequested_size), next_size(nnext_size), start_size(nnext_size),max_size(nmax_size)
+        list(0, 0), requested_size(nrequested_size), init_next_size(nnext_size), next_size(nnext_size), start_size(nnext_size),max_size(nmax_size)
     { //!   Constructs a new empty Pool that can be used to allocate chunks of size RequestedSize.
       //! \param nrequested_size  Requested chunk size
       //! \param  nnext_size parameter is of type size_type,
@@ -688,7 +689,7 @@ bool pool<UserAllocator>::purge_memory()
 
   list.invalidate();
   this->first = 0;
-  next_size = start_size;
+  next_size = start_size = init_next_size;
 
   return true;
 }


### PR DESCRIPTION
```
int main() {
    boost::pool<mark_new_delete> memory_pool(sizeof(int));
    
    for(int i=0;i<40;i++){
        // use malloc to get some memory from pool
        int* data = static_cast<int*>(memory_pool.malloc());
        int* data2 = static_cast<int*>(memory_pool.malloc());

        // release all the memory to the system instead of calling memory_pool.free(data)
        memory_pool.purge_memory();
    }
    return 0;
}
```

Consider the above code, I think it is a normal scenario that users may use, it has the performance issue.

Althought the more correct usage might be call `memory_pool.free()` to free those memory (data1, data2) one by one instead of calling `purge_memory()` at each iteration/rounds.

The current doubling algorithm doesn't reset the start_size and the next_size. If calling `memory_pool.purge_memory()`, the pool releases memory to the system. And the next time `memory_pool.malloc()` is called, the pool asks for the doubled memory from system, which is not expected.